### PR TITLE
Temp Fix: Manually include OpenSSL headers with direct path

### DIFF
--- a/scripts/extract-cert.c
+++ b/scripts/extract-cert.c
@@ -18,10 +18,10 @@
 #include <stdbool.h>
 #include <string.h>
 #include <err.h>
-#include <openssl/bio.h>
-#include <openssl/pem.h>
-#include <openssl/err.h>
-#include <openssl/engine.h>
+#include "/usr/include/openssl/bio.h"
+#include "/usr/include/openssl/pem.h"
+#include "/usr/include/openssl/err.h"
+#include "/usr/include/openssl/engine.h"
 
 #define PKEY_ID_PKCS7 2
 

--- a/scripts/sign-file.c
+++ b/scripts/sign-file.c
@@ -22,12 +22,12 @@
 #include <getopt.h>
 #include <err.h>
 #include <arpa/inet.h>
-#include <openssl/opensslv.h>
-#include <openssl/bio.h>
-#include <openssl/evp.h>
-#include <openssl/pem.h>
-#include <openssl/err.h>
-#include <openssl/engine.h>
+#include "/usr/include/openssl/opensslv.h"
+#include "/usr/include/openssl/bio.h"
+#include "/usr/include/openssl/evp.h"
+#include "/usr/include/openssl/pem.h"
+#include "/usr/include/openssl/err.h"
+#include "/usr/include/openssl/engine.h"
 
 /*
  * Use CMS if we have openssl-1.0.0 or newer available - otherwise we have to

--- a/tools/build/feature/test-libcrypto.c
+++ b/tools/build/feature/test-libcrypto.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
-#include <openssl/evp.h>
-#include <openssl/sha.h>
-#include <openssl/md5.h>
+#include "/usr/include/openssl/evp.h"
+#include "/usr/include/openssl/sha.h"
+#include "/usr/include/openssl/md5.h"
 
 int main(void)
 {

--- a/tools/perf/util/genelf.c
+++ b/tools/perf/util/genelf.c
@@ -46,11 +46,11 @@
 #undef BUILD_ID_URANDOM /* different uuid for each run */
 
 #ifdef BUILD_ID_SHA
-#include <openssl/sha.h>
+#include "/usr/include/openssl/sha.h"
 #endif
 
 #ifdef BUILD_ID_MD5
-#include <openssl/md5.h>
+#include "/usr/include/openssl/md5.h"
 #endif
 #endif
 

--- a/tools/testing/selftests/filesystems/incfs/utils.c
+++ b/tools/testing/selftests/filesystems/incfs/utils.c
@@ -16,8 +16,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include <openssl/sha.h>
-#include <openssl/md5.h>
+#include "/usr/include/openssl/sha.h"
+#include "/usr/include/openssl/md5.h"
 
 #include "utils.h"
 


### PR DESCRIPTION
*Updated source files to use quotes with direct paths for OpenSSL headers (e.g., `/usr/include/openssl/bio.h`) due to build system not detecting OpenSSL headers automatically.